### PR TITLE
Fix `.env.example.dev` copy command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install:
 	ddev composer install
 	@if [ ! -f .env ]; then \
 		if [ -f .env.example.dev ]; then \
-			cp .env.example .env; \
+			cp .env.example.dev .env; \
 			echo ".env file created from .env.example.dev"; \
 		else \
 			echo "Error: .env.example.dev file not found"; \


### PR DESCRIPTION
Fixes the install script to use `.env.example.dev` instead of the non-existent file `.env.example`.